### PR TITLE
Ignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 hs_err_pid*
 docs/_site
 Gemfile.lock
+.ruby-version


### PR DESCRIPTION
`.ruby-version` is used to pin Ruby version locally via `rbenv` when locally `jekyll`ing.

Adding the file to `.gitignore` will help collaborators working on the GitHub Pages website to avoid inadvertently checking in their local `rbenv` config.