### PR TITLE
Refactor: rename AdvancedTrim.Trim() --> AdvancedTrim.trim() .

### DIFF
--- a/src/main/java/scripteditor/AdvancedTrim.java
+++ b/src/main/java/scripteditor/AdvancedTrim.java
@@ -24,11 +24,21 @@
 package scripteditor;
 
 /**
- *
- * @author Administrator
+ * Utility class for trimming Strings.
  */
 public class AdvancedTrim {
 
+    /**
+     * Returns a trimmed copy of a String containing (potentially among other characters) zero or
+     * more sequences of one or more space characters, such that those sequences instead each
+     * have exactly one space character.
+     *
+     * Returns unchanged copies of Strings containing no sequences of multiple space characters.
+     *
+     * @param temp non-null String
+     * @return a copy of temp, except trimming multiple trailing spaces down to just one.
+     * @throws NullPointerException if temp is null
+     */
     public static String Trim(String temp) {
         String ret = "";
         int i = 0;

--- a/src/main/java/scripteditor/AdvancedTrim.java
+++ b/src/main/java/scripteditor/AdvancedTrim.java
@@ -36,7 +36,7 @@ public class AdvancedTrim {
      * Returns unchanged copies of Strings containing no sequences of multiple space characters.
      *
      * @param temp non-null String
-     * @return a copy of temp, except trimming multiple trailing spaces down to just one.
+     * @return a copy of temp, except trimming sequences of multiple spaces down to single spaces.
      * @throws NullPointerException if temp is null
      */
     public static String trim(String temp) {

--- a/src/main/java/scripteditor/AdvancedTrim.java
+++ b/src/main/java/scripteditor/AdvancedTrim.java
@@ -39,7 +39,7 @@ public class AdvancedTrim {
      * @return a copy of temp, except trimming multiple trailing spaces down to just one.
      * @throws NullPointerException if temp is null
      */
-    public static String Trim(String temp) {
+    public static String trim(String temp) {
         String ret = "";
         int i = 0;
         while (i < temp.length()) {

--- a/src/main/java/scripteditor/ImageNamingQuiz.java
+++ b/src/main/java/scripteditor/ImageNamingQuiz.java
@@ -104,7 +104,7 @@ public class ImageNamingQuiz {
                     break;
                 }
                 String completeAnswer = mSessionInfo.mImageCollection.getImageName();
-                completeAnswer = AdvancedTrim.Trim(completeAnswer);
+                completeAnswer = AdvancedTrim.trim(completeAnswer);
                 user_response = dlgQR.getResponse().trim();
                 actual_answer = getParsedName(completeAnswer.toLowerCase().trim());
 

--- a/src/main/java/scripteditor/ImageNamingQuiz2.java
+++ b/src/main/java/scripteditor/ImageNamingQuiz2.java
@@ -144,11 +144,11 @@ public class ImageNamingQuiz2 {
                 else{
                    tempPart = mSessionInfo.mImageCollection.getImageName().toLowerCase().trim();
                  
-                   String ans=AdvancedTrim.Trim(mSessionInfo.mImageCollection.getImageName());
+                   String ans=AdvancedTrim.trim(mSessionInfo.mImageCollection.getImageName());
                    
                    String answer=getParsedName(ans);
                    
-                   tempPart = AdvancedTrim.Trim(tempPart);
+                   tempPart = AdvancedTrim.trim(tempPart);
                  //String completeAnswer = tempPart;//Commented by preethy on 11-04-2012
                  String completeAnswer = mSessionInfo.mImageCollection.getImageName();//Added by preethy on 11-04-2012
                 actual_answer = getParsedName(completeAnswer.toLowerCase().trim());

--- a/src/main/java/scripteditor/ImageNamingTest.java
+++ b/src/main/java/scripteditor/ImageNamingTest.java
@@ -86,7 +86,7 @@ public class ImageNamingTest {
                 {
                 tempPart = mSessionInfo.mImageCollection.getImageName().toLowerCase().trim();
                  
-                tempPart = AdvancedTrim.Trim(tempPart);
+                tempPart = AdvancedTrim.trim(tempPart);
               //  String completeAnswer = tempPart;//Commented by preethy on 11-04-2012
                  String completeAnswer = mSessionInfo.mImageCollection.getImageName();//Added by preethy on 11-04-2012
                 tempPart = getParsedName(tempPart);

--- a/src/main/java/scripteditor/ImageNamingTest2.java
+++ b/src/main/java/scripteditor/ImageNamingTest2.java
@@ -94,7 +94,7 @@ public class ImageNamingTest2 {
                 {
                
                 tempPart = mSessionInfo.mImageCollection.getImageName().toLowerCase().trim();
-                tempPart = AdvancedTrim.Trim(tempPart);
+                tempPart = AdvancedTrim.trim(tempPart);
                 String completeAnswer = tempPart;
                 tempPart = getParsedName(tempPart);
                 

--- a/src/main/java/scripteditor/ImageNamingTestScript.java
+++ b/src/main/java/scripteditor/ImageNamingTestScript.java
@@ -78,7 +78,7 @@ public class ImageNamingTestScript {
                 }
                 user_response = dlgQR.getResponse().trim();
                 tempPart = mSessionInfo.mImageCollection.getImageName().toLowerCase().trim();
-                tempPart = AdvancedTrim.Trim(tempPart);
+                tempPart = AdvancedTrim.trim(tempPart);
                 String completeAnswer = tempPart;
                 tempPart = getParsedName(tempPart);
 

--- a/src/test/java/scripteditor/AdvancedTrimTest.java
+++ b/src/test/java/scripteditor/AdvancedTrimTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package scripteditor;
+
+import junit.framework.TestCase;
+
+/**
+ * This test case documents the behavior of AdvancedTrim.Trim() as discovered.
+ */
+public class AdvancedTrimTest extends TestCase {
+
+    /**
+     * Test that Trim() returns alphanumerics unchanged.
+     */
+    public void testTrimIsANoOpOnAlphanumerics() {
+
+        final String alphanumeric = "abcABC123";
+
+        assertEquals(alphanumeric, AdvancedTrim.Trim(alphanumeric));
+
+    }
+
+    /**
+     * Test that Trim() trims a String with multiple trailing space characters down to one
+     * trailing space character.
+     */
+    public void testTrimsToOneTrailingWhitespace() {
+
+        final String severalSpacesTrail = "whitespace-follows   ";
+        final String justOneSpaceTrails = "whitespace-follows ";
+
+        assertEquals(justOneSpaceTrails, AdvancedTrim.Trim(severalSpacesTrail));
+
+    }
+
+    /**
+     * Test that Trim() trims a String with multiple leading space characters down to one leading
+     * space character.
+     */
+    public void testTrimsToOneLeadingWhitespace() {
+
+        final String severalSpacesLead = "   whitespace-led";
+        final String justOneSpaceLeads = " whitespace-led";
+
+        assertEquals(justOneSpaceLeads, AdvancedTrim.Trim(severalSpacesLead));
+    }
+
+    /**
+     * Test that Trim() trims a String containing multiple sequences of multiple space characters
+     * down to one space character in place of each such sequence.
+     */
+    public void testTrimsToOneEmbeddedWhitespaceSequences() {
+
+        final String severalSequencesOfSeveralSpacesEmbedded =
+            "unit    testing is   good for the    soul";
+
+        final String onlyIsolatedSpacesRemain =
+            "unit testing is good for the soul";
+
+        assertEquals(onlyIsolatedSpacesRemain,
+            AdvancedTrim.Trim(severalSequencesOfSeveralSpacesEmbedded));
+    }
+
+}

--- a/src/test/java/scripteditor/AdvancedTrimTest.java
+++ b/src/test/java/scripteditor/AdvancedTrimTest.java
@@ -22,23 +22,23 @@ package scripteditor;
 import junit.framework.TestCase;
 
 /**
- * This test case documents the behavior of AdvancedTrim.Trim() as discovered.
+ * This test case documents the behavior of AdvancedTrim.trim() as discovered.
  */
 public class AdvancedTrimTest extends TestCase {
 
     /**
-     * Test that Trim() returns alphanumerics unchanged.
+     * Test that trim() returns alphanumerics unchanged.
      */
     public void testTrimIsANoOpOnAlphanumerics() {
 
         final String alphanumeric = "abcABC123";
 
-        assertEquals(alphanumeric, AdvancedTrim.Trim(alphanumeric));
+        assertEquals(alphanumeric, AdvancedTrim.trim(alphanumeric));
 
     }
 
     /**
-     * Test that Trim() trims a String with multiple trailing space characters down to one
+     * Test that trim() trims a String with multiple trailing space characters down to one
      * trailing space character.
      */
     public void testTrimsToOneTrailingWhitespace() {
@@ -46,12 +46,12 @@ public class AdvancedTrimTest extends TestCase {
         final String severalSpacesTrail = "whitespace-follows   ";
         final String justOneSpaceTrails = "whitespace-follows ";
 
-        assertEquals(justOneSpaceTrails, AdvancedTrim.Trim(severalSpacesTrail));
+        assertEquals(justOneSpaceTrails, AdvancedTrim.trim(severalSpacesTrail));
 
     }
 
     /**
-     * Test that Trim() trims a String with multiple leading space characters down to one leading
+     * Test that trim() trims a String with multiple leading space characters down to one leading
      * space character.
      */
     public void testTrimsToOneLeadingWhitespace() {
@@ -59,11 +59,11 @@ public class AdvancedTrimTest extends TestCase {
         final String severalSpacesLead = "   whitespace-led";
         final String justOneSpaceLeads = " whitespace-led";
 
-        assertEquals(justOneSpaceLeads, AdvancedTrim.Trim(severalSpacesLead));
+        assertEquals(justOneSpaceLeads, AdvancedTrim.trim(severalSpacesLead));
     }
 
     /**
-     * Test that Trim() trims a String containing multiple sequences of multiple space characters
+     * Test that trim() trims a String containing multiple sequences of multiple space characters
      * down to one space character in place of each such sequence.
      */
     public void testTrimsToOneEmbeddedWhitespaceSequences() {
@@ -75,7 +75,7 @@ public class AdvancedTrimTest extends TestCase {
             "unit testing is good for the soul";
 
         assertEquals(onlyIsolatedSpacesRemain,
-            AdvancedTrim.Trim(severalSequencesOfSeveralSpacesEmbedded));
+            AdvancedTrim.trim(severalSequencesOfSeveralSpacesEmbedded));
     }
 
 }


### PR DESCRIPTION
Syle: Java method names should be `camelCase` rather than `TitleCase`, so `AdvancedTrim.trim( String )` rather than `AdvancedTrim.Trim( String )`.

Supported by unit test discovering, staving off regression of the behavior of the pre-existing `Trim()` method and JavaDoc documenting the behavior. (Commit sequence *first* tests and documents, *then* refactors.)

(Verified `mvn package` still succeeds, new unit test and all, and resulting `.app` launches.)