### PR TITLE
Naively configure travis-ci .

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # ImageQuiz
 
+[![Travis continuous integration build status badge](https://travis-ci.org/Jasig/ImageQuiz.svg?branch=master)](https://travis-ci.org/Jasig/ImageQuiz)
+
 See [the documentation website](http://jasig.github.io/ImageQuiz).


### PR DESCRIPTION
+ Add simplest possible Travis-CI configuration for a Java project ( `.travis.yml` )
+ Add build status badge to `README.md`

in order to stave off potential future regressions that might break the build or fail a unit test.

Travis will only actually run, and the README badge become interesting, when a project admin turns on Travis-CI for this repository. Until then, the configuration and badge are harmless no-ops.

[Demonstrated working](https://travis-ci.org/apetro/ImageQuiz/builds/198248090) on my fork of the repository, where I have turned Travis-CI on.